### PR TITLE
feat: add support for TousAntiCovid QRCode v2

### DIFF
--- a/src/lib/2ddoc.ts
+++ b/src/lib/2ddoc.ts
@@ -141,9 +141,18 @@ const TOTAL_REGEX = new RegExp(
 
 function extractLink(doc: string): string {
 	doc = doc.trim();
-	if (doc.startsWith('http')) {
+	
+	// TousAntiCovid QRCode v1
+	if (doc.startsWith('https://bonjour.tousanticovid.gouv.fr/app/wallet?v=')) {
 		return new URL(doc).searchParams.get('v') || '';
 	}
+
+	// TousAntiCovid QRCode v2
+	if (doc.startsWith('https://bonjour.tousanticovid.gouv.fr/app/wallet2d#')) {
+		const url = new URL(doc);
+		return url.hash.length > 0 ? decodeURI(url.hash.substring(1)) : '';
+	}
+
 	return doc;
 }
 


### PR DESCRIPTION
Les "deeplinks" TousAntiCovid ont été modifiés pour mieux respecter la vie privée des utilisateurs:

Avant (v1): `https://bonjour.tousanticovid.gouv.fr/app/wallet?v=DC04FR03AV01[...]`

Après (v2): `https://bonjour.tousanticovid.gouv.fr/app/wallet2d#DC04FR03AV01[...]`

Commit TousAntiCovid mentionnant le changement de format: https://gitlab.inria.fr/stopcovid19/stopcovid-android/-/commit/e02b12baf09ec492a559a6cd300cd68159048d81

Cette modification permet à l'application de gérer les deux possibilités désormais.