### PR TITLE
feat: Extract more information from 2D-Doc + improvements to post-scan technical information

### DIFF
--- a/src/lib/2ddoc.ts
+++ b/src/lib/2ddoc.ts
@@ -36,11 +36,7 @@ const CERTIFICATE_AUTHORITIES = new Map<string, string>([
 	['FR05', 'ANTS']
 ]);
 
-export function getCertificateAuthority(certificateAuthorityId?: string): string | undefined {
-	if (certificateAuthorityId === undefined) {
-		return '';
-	}
-
+export function getCertificateAuthority(certificateAuthorityId: string): string | undefined {
 	const certificateAuthority = CERTIFICATE_AUTHORITIES.get(certificateAuthorityId);
 
 	if (certificateAuthority === undefined) {
@@ -59,11 +55,7 @@ const PUBLIC_KEYS = new Map<string, string>([
 	['AV02', 'Caisse Nationale d\'Assurance Maladie (CNAM)'],
 ]);
 
-export function getPublicKey(publicKeyId?: string): string | undefined {
-	if (publicKeyId === undefined) {
-		return '';
-	}
-
+export function getPublicKey(publicKeyId: string): string | undefined {
 	const publicKey = PUBLIC_KEYS.get(publicKeyId);
 
 	if (publicKey === undefined) {
@@ -150,14 +142,14 @@ export type TestCertificate = OBJECT_WITH_FIELDS<typeof TEST_FIELDS>;
 export type VaccineCertificate = OBJECT_WITH_FIELDS<typeof VACCINE_FIELDS>;
 interface HeaderData {
 	code: string,
-	creation_date?: Date,
-	signature_date?: Date,
-	certificate_authority_id?: string,
-	public_key_id?: string,
-	document_version?: string,
-	document_type?: string,
-	document_perimeter?: string,
-	document_country?: string,
+	creation_date: Date,
+	signature_date: Date,
+	certificate_authority_id: string,
+	public_key_id: string,
+	document_version: string,
+	document_type: string,
+	document_perimeter: string,
+	document_country: string,
 }
 export type Certificate = (VaccineCertificate | TestCertificate) & HeaderData & { signature?: string };
 

--- a/src/lib/2ddoc.ts
+++ b/src/lib/2ddoc.ts
@@ -36,7 +36,11 @@ const CERTIFICATE_AUTHORITIES = new Map<string, string>([
 	['FR05', 'ANTS']
 ]);
 
-export function getCertificateAuthority(certificateAuthorityId: string): string | undefined {
+export function getCertificateAuthority(certificateAuthorityId?: string): string | undefined {
+	if (certificateAuthorityId === undefined) {
+		return '';
+	}
+
 	const certificateAuthority = CERTIFICATE_AUTHORITIES.get(certificateAuthorityId);
 
 	if (certificateAuthority === undefined) {
@@ -47,7 +51,7 @@ export function getCertificateAuthority(certificateAuthorityId: string): string 
 }
 
 // Correspondance identifiant du certificat (Ex: AHP1) et nom de l'entité (Ex: Assistance Publique Hopitaux de Paris)
-// Source: certificates.certigna.fr/search.php?name=[ID_CERTIFICAT]
+// Source: http://certificates.certigna.fr/search.php?name=[ID_CERTIFICAT]
 const PUBLIC_KEYS = new Map<string, string>([
 	['AHP1', 'Assistance Publique Hopitaux de Paris (APHP)'],
 	['AHP2', 'Assistance Publique Hopitaux de Paris (APHP)'],
@@ -55,7 +59,11 @@ const PUBLIC_KEYS = new Map<string, string>([
 	['AV02', 'Caisse Nationale d\'Assurance Maladie (CNAM)'],
 ]);
 
-export function getPublicKey(publicKeyId: string): string | undefined {
+export function getPublicKey(publicKeyId?: string): string | undefined {
+	if (publicKeyId === undefined) {
+		return '';
+	}
+
 	const publicKey = PUBLIC_KEYS.get(publicKeyId);
 
 	if (publicKey === undefined) {

--- a/src/lib/2ddoc.ts
+++ b/src/lib/2ddoc.ts
@@ -26,6 +26,8 @@ const DATE = {
 	}
 };
 
+// Correspondance code court (Ex: FR03) et nom de l'autorité (Ex: Dhimyotis)
+// Source: https://ants.gouv.fr/content/download/517/5670/version/23/file/TLS_valide-signed-xades-baseline-b.xml
 const CERTIFICATE_AUTHORITIES = new Map<string, string>([
 	['FR01', 'AriadNEXT'],
 	['FR02', 'LEX PERSONA'],
@@ -44,6 +46,8 @@ export function getCertificateAuthority(certificateAuthorityId: string): string 
 	return certificateAuthority;
 }
 
+// Correspondance identifiant du certificat (Ex: AHP1) et nom de l'entité (Ex: Assistance Publique Hopitaux de Paris)
+// Source: certificates.certigna.fr/search.php?name=[ID_CERTIFICAT]
 const PUBLIC_KEYS = new Map<string, string>([
 	['AHP1', 'Assistance Publique Hopitaux de Paris (APHP)'],
 	['AHP2', 'Assistance Publique Hopitaux de Paris (APHP)'],
@@ -61,6 +65,8 @@ export function getPublicKey(publicKeyId: string): string | undefined {
 	return publicKey;
 }
 
+// Source: https://ants.gouv.fr/content/download/516/5665/version/11/file/Specifications-techniques-des-codes-a-barres_2D-Doc_v3.1.3.pdf
+// 7.14. Identifiants de données relatives aux résultats des tests virologiques - F3 (Page 81)
 export function getSex(sex: string): string {
 	switch (sex) {
 		case 'M':
@@ -72,6 +78,8 @@ export function getSex(sex: string): string {
 	}
 }
 
+// Source: https://ants.gouv.fr/content/download/516/5665/version/11/file/Specifications-techniques-des-codes-a-barres_2D-Doc_v3.1.3.pdf
+// 7.14. Identifiants de données relatives aux résultats des tests virologiques - F5 (Page 81)
 export function getAnalysisResult(analysisResult: string): string {
 	switch (analysisResult) {
 		case 'P':

--- a/src/routes/_Certificate.svelte
+++ b/src/routes/_Certificate.svelte
@@ -1,5 +1,5 @@
 <script type="ts">
-	import { Alert, Row, Col, Icon, Table, Accordion, AccordionItem } from 'sveltestrap';
+	import { Alert, Row, Col, Icon, Table, Card, CardHeader, CardBody, CardTitle } from 'sveltestrap';
 	import { findCertificateError, getNamesAndBirthdate, getCertificateAuthority, getPublicKey, getSex, getAnalysisResult } from '$lib/2ddoc';
 	import type { Certificate } from '../lib/2ddoc';
 	export let certificate: Certificate;
@@ -31,15 +31,16 @@
 			<p class="error">⚠️ <strong>{error}</strong></p>
 		{/if}
 
-		<Accordion>
-			<AccordionItem header="Données techniques">
-				<Accordion>
-					<AccordionItem header="Données brutes">
-						<code>{certificate.code}</code>
-					</AccordionItem>
-
-					<AccordionItem header="Informations entête">
-						<Table>
+		<p>
+			<details>
+				<summary>Détails techniques</summary>
+				
+				<Card class="mb-3 mt-3">
+					<CardHeader>
+						<CardTitle>Informations entête</CardTitle>
+					</CardHeader>
+					<CardBody>
+						<Table class="table-sm">
 							<tbody>
 								<tr>
 									<th class="text-start">Version 2D-Doc</th>
@@ -55,15 +56,15 @@
 								</tr>
 								<tr>
 									<th class="text-start">ID Autorité de certification</th>
-									<td class="text-end"><abbr title="{getCertificateAuthority(certificate.certificate_authority_id)}">{certificate.certificate_authority_id}</abbr></td>
+									<td class="text-end">{getCertificateAuthority(certificate.certificate_authority_id)} <small>({certificate.certificate_authority_id})</small></td>
 								</tr>
 								<tr>
 									<th class="text-start">ID Certificat</th>
-									<td class="text-end"><abbr title="{getPublicKey(certificate.public_key_id)}">{certificate.public_key_id}</abbr></td>
+									<td class="text-end">{getPublicKey(certificate.public_key_id)} <small>({certificate.public_key_id})</small></td>
 								</tr>
 								<tr>
 									<th class="text-start">Type document</th>
-									<td class="text-end"><abbr title="{certificate.document_type == 'B2' ? 'Résultat de test virologique' : 'Attestation vaccinale'}">{certificate.document_type}</abbr></td>
+									<td class="text-end">{certificate.document_type == 'B2' ? 'Résultat de test virologique' : 'Attestation vaccinale'} <small>({certificate.document_type})</small></td>
 								</tr>
 								<tr>
 									<th class="text-start">Perimetre</th>
@@ -75,117 +76,165 @@
 								</tr>
 							</tbody>
 						</Table>
-					</AccordionItem>
+					</CardBody>
+				</Card>
 
-					<AccordionItem header="Informations message">
-						<Table>
+				<Card class="mb-3">
+					<CardHeader>
+						<CardTitle>Informations message</CardTitle>
+					</CardHeader>
+					<CardBody>
+						<Table class="table-sm">
 							<tbody>
+								{#if 'tested_first_name' in certificate}
 								<tr>
 									<th class="text-start">Prénom(s)</th>
-									<td class="text-end">{certificate.tested_first_name ? certificate.tested_first_name : certificate.vaccinated_first_name}</td>
-								</tr>
-								<tr>
-									<th class="text-start">Nom</th>
-									<td class="text-end">{certificate.tested_last_name ? certificate.tested_last_name : certificate.vaccinated_last_name}</td>
-								</tr>
-								<tr>
-									<th class="text-start">Date de naissance</th>
-									<td class="text-end">{(certificate.tested_birth_date ? certificate.tested_birth_date : certificate.vaccinated_birth_date).toLocaleDateString('fr-FR')}</td>
-								</tr>
-
-								{#if certificate.sex}
-								<tr>
-									<th class="text-start">Genre</th>
-									<td class="text-end"><abbr title="{getSex(certificate.sex)}">{certificate.sex}</abbr></td>
+									<td class="text-end">{certificate.tested_first_name}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.analysis_code}
+								{#if 'tested_last_name' in certificate}
+								<tr>
+									<th class="text-start">Nom</th>
+									<td class="text-end">{certificate.tested_last_name}</td>
+								</tr>
+								{/if}
+
+								{#if 'tested_birth_date' in certificate}
+								<tr>
+									<th class="text-start">Date de naissance</th>
+									<td class="text-end">{certificate.tested_birth_date.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								{/if}
+								
+								{#if 'vaccinatedd_first_name' in certificate}
+								<tr>
+									<th class="text-start">Prénom(s)</th>
+									<td class="text-end">{certificate.vaccinated_first_name}</td>
+								</tr>
+								{/if}
+
+								{#if 'vaccinated_last_name' in certificate}
+								<tr>
+									<th class="text-start">Nom</th>
+									<td class="text-end">{certificate.vaccinated_last_name}</td>
+								</tr>
+								{/if}
+
+								{#if 'vaccinated_birth_date' in certificate}
+								<tr>
+									<th class="text-start">Date de naissance</th>
+									<td class="text-end">{certificate.vaccinated_birth_date.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								{/if}
+
+								{#if 'sex' in certificate}
+								<tr>
+									<th class="text-start">Genre</th>
+									<td class="text-end">{getSex(certificate.sex)} <small>({certificate.sex})</small></td>
+								</tr>
+								{/if}
+
+								{#if 'analysis_code' in certificate}
 								<tr>
 									<th class="text-start">Code analyse</th>
 									<td class="text-end">{certificate.analysis_code}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.analysis_result}
+								{#if 'analysis_result' in certificate}
 								<tr>
 									<th class="text-start">Resultat analyse</th>
-									<td class="text-end"><abbr title="{getAnalysisResult(certificate.analysis_result)}">{certificate.analysis_result}</abbr></td>
+									<td class="text-end">{getAnalysisResult(certificate.analysis_result)} <small>({certificate.analysis_result})</small></td>
 								</tr>
 								{/if}
 
-								{#if certificate.analysis_datetime}
+								{#if 'analysis_datetime' in certificate}
 								<tr>
 									<th class="text-start">Date prélèvement</th>
 									<td class="text-end">{certificate.analysis_datetime.toLocaleDateString('fr-FR')}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.disease}
+								{#if 'disease' in certificate}
 								<tr>
 									<th class="text-start">Maladie couverte</th>
 									<td class="text-end">{certificate.disease}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.prophylactic_agent}
+								{#if 'prophylactic_agent' in certificate}
 								<tr>
 									<th class="text-start"><a href="https://fr.wikipedia.org/wiki/Classification_ATC" target="_blank">Agent prophylactique</a></th>
 									<td class="text-end">{certificate.prophylactic_agent}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.vaccine}
+								{#if 'vaccine' in certificate}
 								<tr>
 									<th class="text-start">Nom vaccin</th>
 									<td class="text-end">{certificate.vaccine}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.vaccine_maker}
+								{#if 'vaccine_maker' in certificate}
 								<tr>
 									<th class="text-start">Fabricant vaccin</th>
 									<td class="text-end">{certificate.vaccine_maker}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.doses_received}
+								{#if 'doses_received' in certificate}
 								<tr>
 									<th class="text-start">Doses reçues</th>
 									<td class="text-end">{certificate.doses_received}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.doses_expected}
+								{#if 'doses_expected' in certificate}
 								<tr>
 									<th class="text-start">Doses attendues</th>
 									<td class="text-end">{certificate.doses_expected}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.last_dose_date}
+								{#if 'last_dose_date' in certificate}
 								<tr>
 									<th class="text-start">Date dernière dose</th>
 									<td class="text-end">{certificate.last_dose_date.toLocaleDateString('fr-FR')}</td>
 								</tr>
 								{/if}
 
-								{#if certificate.cycle_state}
+								{#if 'cycle_state' in certificate}
 								<tr>
 									<th class="text-start">Etat vaccination</th>
-									<td class="text-end"><abbr title="{certificate.cycle_state === 'TE' ? 'Terminé' : 'En cours'}">{certificate.cycle_state}</abbr></td>
+									<td class="text-end">{certificate.cycle_state === 'TE' ? 'Terminé' : 'En cours'} <small>({certificate.cycle_state})</small></td>
 								</tr>
 								{/if}
 							</tbody>
 						</Table>
-					</AccordionItem>
+					</CardBody>
+				</Card>
 
-					<AccordionItem header="Informations signature">
+				<Card class="mb-3">
+					<CardHeader>
+						<CardTitle>Informations signature</CardTitle>
+					</CardHeader>
+					<CardBody>
 						<code>{ certificate.signature }</code>
-					</AccordionItem>
-				</Accordion>
-			</AccordionItem>
-		</Accordion>
+					</CardBody>
+				</Card>
+
+				<Card class="mb-3">
+					<CardHeader>
+						<CardTitle>Données brutes</CardTitle>
+					</CardHeader>
+					<CardBody>
+						<code>{certificate.code}</code>
+					</CardBody>
+				</Card>
+			</details>
+		</p>
 	</div>
 </Alert>
 

--- a/src/routes/_Certificate.svelte
+++ b/src/routes/_Certificate.svelte
@@ -1,5 +1,5 @@
 <script type="ts">
-	import { Alert, Row, Col, Icon, Table, Card, CardHeader, CardBody, CardTitle } from 'sveltestrap';
+	import { Alert, Icon, Table, Card, CardHeader, CardBody, CardTitle } from 'sveltestrap';
 	import { findCertificateError, getNamesAndBirthdate, getCertificateAuthority, getPublicKey, getSex, getAnalysisResult } from '$lib/2ddoc';
 	import type { Certificate } from '../lib/2ddoc';
 	export let certificate: Certificate;
@@ -48,11 +48,11 @@
 								</tr>
 								<tr>
 									<th scope="row" class="text-start">Date de création</th>
-									<td class="text-end">{certificate.creation_date.toLocaleDateString('fr-FR')}</td>
+									<td class="text-end">{certificate.creation_date ? certificate.creation_date.toLocaleDateString('fr-FR') : ' - '}</td>
 								</tr>
 								<tr>
 									<th class="text-start">Date de signature</th>
-									<td class="text-end">{certificate.signature_date.toLocaleDateString('fr-FR')}</td>
+									<td class="text-end">{certificate.signature_date ? certificate.signature_date.toLocaleDateString('fr-FR') : ' - '}</td>
 								</tr>
 								<tr>
 									<th class="text-start">ID Autorité de certification</th>
@@ -107,7 +107,7 @@
 								</tr>
 								{/if}
 								
-								{#if 'vaccinatedd_first_name' in certificate}
+								{#if 'vaccinated_first_name' in certificate}
 								<tr>
 									<th class="text-start">Prénom(s)</th>
 									<td class="text-end">{certificate.vaccinated_first_name}</td>
@@ -239,17 +239,10 @@
 </Alert>
 
 <style>
-	.emoji {
-		font-size: 4em;
-		margin: auto;
-	}
 	.first_name {
 		text-transform: capitalize;
 	}
 	p {
 		margin-bottom: 0.5rem;
-	}
-	pre {
-		font-size: 0.8em;
 	}
 </style>

--- a/src/routes/_Certificate.svelte
+++ b/src/routes/_Certificate.svelte
@@ -1,6 +1,6 @@
 <script type="ts">
-	import { Alert, Row, Col, Icon } from 'sveltestrap';
-	import { findCertificateError, getNamesAndBirthdate } from '$lib/2ddoc';
+	import { Alert, Row, Col, Icon, Table, Accordion, AccordionItem } from 'sveltestrap';
+	import { findCertificateError, getNamesAndBirthdate, getCertificateAuthority, getPublicKey, getSex, getAnalysisResult } from '$lib/2ddoc';
 	import type { Certificate } from '../lib/2ddoc';
 	export let certificate: Certificate;
 	export let with_fullscreen = false;
@@ -15,27 +15,178 @@
 			<Icon name="arrows-fullscreen" />
 		</a>
 	{/if}
-	<h4 class="text-center">{vaccine ? 'Vaccin' : 'Test de dépistage'}</h4>
-	<Row>
-		<div class="col-sm-0 col-md-3 text-center align-middle emoji">{vaccine ? '💉' : '🧪'}</div>
-		<Col sm="12" md="9">
-			<p>
-				👤
-				<span class="first_name">{info.first_name.toLocaleLowerCase()}</span>
-				<span class="last_name">{info.last_name}</span>
-			</p>
-			<p>🎂 Né(e) le {info.birth_date.toLocaleDateString('fr')}</p>
-			{#if error}
-				<p class="error">⚠️ <strong>{error}</strong></p>
-			{/if}
-			<p>
-				<details>
-					<summary>Détails techniques</summary>
-					<pre>{JSON.stringify(certificate, null, '  ')}</pre>
-				</details>
-			</p>
-		</Col>
-	</Row>
+	<h4 class="text-center">{vaccine ? '💉 Vaccin' : '🧪 Test de dépistage'}</h4>
+
+	<div class="text-center">
+		<p>
+			👤
+			<span class="first_name">{info.first_name.toLocaleLowerCase()}</span>
+			<span class="last_name">{info.last_name}</span>
+		</p>
+		<p>🎂 Né(e) le {info.birth_date.toLocaleDateString('fr')}</p>
+
+		<br>
+
+		{#if error}
+			<p class="error">⚠️ <strong>{error}</strong></p>
+		{/if}
+
+		<Accordion>
+			<AccordionItem header="Données techniques">
+				<Accordion>
+					<AccordionItem header="Données brutes">
+						<code>{certificate.code}</code>
+					</AccordionItem>
+
+					<AccordionItem header="Informations entête">
+						<Table>
+							<tbody>
+								<tr>
+									<th class="text-start">Version 2D-Doc</th>
+									<td class="text-end">{certificate.document_version}</td>
+								</tr>
+								<tr>
+									<th scope="row" class="text-start">Date de création</th>
+									<td class="text-end">{certificate.creation_date.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								<tr>
+									<th class="text-start">Date de signature</th>
+									<td class="text-end">{certificate.signature_date.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								<tr>
+									<th class="text-start">ID Autorité de certification</th>
+									<td class="text-end"><abbr title="{getCertificateAuthority(certificate.certificate_authority_id)}">{certificate.certificate_authority_id}</abbr></td>
+								</tr>
+								<tr>
+									<th class="text-start">ID Certificat</th>
+									<td class="text-end"><abbr title="{getPublicKey(certificate.public_key_id)}">{certificate.public_key_id}</abbr></td>
+								</tr>
+								<tr>
+									<th class="text-start">Type document</th>
+									<td class="text-end"><abbr title="{certificate.document_type == 'B2' ? 'Résultat de test virologique' : 'Attestation vaccinale'}">{certificate.document_type}</abbr></td>
+								</tr>
+								<tr>
+									<th class="text-start">Perimetre</th>
+									<td class="text-end">{certificate.document_perimeter}</td>
+								</tr>
+								<tr>
+									<th class="text-start">Pays emetteur</th>
+									<td class="text-end">{certificate.document_country}</td>
+								</tr>
+							</tbody>
+						</Table>
+					</AccordionItem>
+
+					<AccordionItem header="Informations message">
+						<Table>
+							<tbody>
+								<tr>
+									<th class="text-start">Prénom(s)</th>
+									<td class="text-end">{certificate.tested_first_name ? certificate.tested_first_name : certificate.vaccinated_first_name}</td>
+								</tr>
+								<tr>
+									<th class="text-start">Nom</th>
+									<td class="text-end">{certificate.tested_last_name ? certificate.tested_last_name : certificate.vaccinated_last_name}</td>
+								</tr>
+								<tr>
+									<th class="text-start">Date de naissance</th>
+									<td class="text-end">{(certificate.tested_birth_date ? certificate.tested_birth_date : certificate.vaccinated_birth_date).toLocaleDateString('fr-FR')}</td>
+								</tr>
+
+								{#if certificate.sex}
+								<tr>
+									<th class="text-start">Genre</th>
+									<td class="text-end"><abbr title="{getSex(certificate.sex)}">{certificate.sex}</abbr></td>
+								</tr>
+								{/if}
+
+								{#if certificate.analysis_code}
+								<tr>
+									<th class="text-start">Code analyse</th>
+									<td class="text-end">{certificate.analysis_code}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.analysis_result}
+								<tr>
+									<th class="text-start">Resultat analyse</th>
+									<td class="text-end"><abbr title="{getAnalysisResult(certificate.analysis_result)}">{certificate.analysis_result}</abbr></td>
+								</tr>
+								{/if}
+
+								{#if certificate.analysis_datetime}
+								<tr>
+									<th class="text-start">Date prélèvement</th>
+									<td class="text-end">{certificate.analysis_datetime.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.disease}
+								<tr>
+									<th class="text-start">Maladie couverte</th>
+									<td class="text-end">{certificate.disease}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.prophylactic_agent}
+								<tr>
+									<th class="text-start"><a href="https://fr.wikipedia.org/wiki/Classification_ATC" target="_blank">Agent prophylactique</a></th>
+									<td class="text-end">{certificate.prophylactic_agent}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.vaccine}
+								<tr>
+									<th class="text-start">Nom vaccin</th>
+									<td class="text-end">{certificate.vaccine}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.vaccine_maker}
+								<tr>
+									<th class="text-start">Fabricant vaccin</th>
+									<td class="text-end">{certificate.vaccine_maker}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.doses_received}
+								<tr>
+									<th class="text-start">Doses reçues</th>
+									<td class="text-end">{certificate.doses_received}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.doses_expected}
+								<tr>
+									<th class="text-start">Doses attendues</th>
+									<td class="text-end">{certificate.doses_expected}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.last_dose_date}
+								<tr>
+									<th class="text-start">Date dernière dose</th>
+									<td class="text-end">{certificate.last_dose_date.toLocaleDateString('fr-FR')}</td>
+								</tr>
+								{/if}
+
+								{#if certificate.cycle_state}
+								<tr>
+									<th class="text-start">Etat vaccination</th>
+									<td class="text-end"><abbr title="{certificate.cycle_state === 'TE' ? 'Terminé' : 'En cours'}">{certificate.cycle_state}</abbr></td>
+								</tr>
+								{/if}
+							</tbody>
+						</Table>
+					</AccordionItem>
+
+					<AccordionItem header="Informations signature">
+						<code>{ certificate.signature }</code>
+					</AccordionItem>
+				</Accordion>
+			</AccordionItem>
+		</Accordion>
+	</div>
 </Alert>
 
 <style>

--- a/src/routes/_CodeFound.svelte
+++ b/src/routes/_CodeFound.svelte
@@ -43,12 +43,14 @@
 		</Alert>
 	</div>
 {:else if codeFound && parsed}
-	<Modal isOpen={!!codeFound} {toggle}>
+	<Modal isOpen={!!codeFound} {toggle} size="lg">
+
+		{#if $invitedTo.eventId}
 		<ModalHeader>
-			{#if $invitedTo.eventId}Confirmer ma présence
-			{:else}Certificat détecté
-			{/if}
+			Confirmer ma présence
 		</ModalHeader>
+		{/if}
+
 		<ModalBody>
 			<CertificateBox certificate={parsed} />
 			<ShowPromiseError {promise} />


### PR DESCRIPTION
Ces modifications permettent d'extraire plus d'informations du document 2D-Doc, comme:
* L'identifiant de l'autorité de certification (Exemple: `FR03`)
* L'identifiant du certificat (Exemple: `AHP1`)
* La version du 2D-Doc (Exemple: `04`)
* Le périmètre du 2D-Doc (Exemple: `01`)
* Le pays émetteur du document (Exemple: `FR`)

Des tableaux de correspondance internes à l'application permettent de retrouver des valeurs plus parlantes pour certaines informations, comme:
* L'identifiant de l'autorité de certification (Exemple: `FR03` => `Dhimyotis`)
* L'identifiant du certificat (Exemple: `AHP1` => `Assistance Publique Hopitaux de Paris (APHP)`)
* Le genre du patient lors d'un test (Exemple: `M` => `Masculin`)
* Le résultat d'un test (Exemple: `P` => `Positif`)

Ce qui permet d'améliorer l'affichage des informations techniques suite à un scan (les emojis ne veulent pas fonctionner sur Chromium Linux...):

![Document 2D-Doc - Données brutes](https://user-images.githubusercontent.com/821228/121790820-fd68b300-cbd2-11eb-9b8d-b9dbaaf69e60.png)
![Document 2D-Doc - Informations entêtes](https://user-images.githubusercontent.com/821228/121790824-0063a380-cbd3-11eb-92aa-d899901c6c5c.png)
![Attestation vaccination - Informations message ](https://user-images.githubusercontent.com/821228/121790825-02c5fd80-cbd3-11eb-82f4-447a586fe893.png)
![Resultat analyse - Informations message](https://user-images.githubusercontent.com/821228/121790842-3acd4080-cbd3-11eb-9701-88cce766f640.png)
![Document 2D-Doc - Informations signature](https://user-images.githubusercontent.com/821228/121790827-048fc100-cbd3-11eb-8ed7-379f3d4b7682.png)
