### PR TITLE
Ne pas stocker en mémoire le code si non nécessaire

### DIFF
--- a/src/routes/borne/_scan.svelte
+++ b/src/routes/borne/_scan.svelte
@@ -38,6 +38,9 @@
 		const cert = await parse_any(code);
 		const error = findCertificateError(cert);
 		if (error) throw new Error(error);
+		if (prevent_revalidation_before_ms === 0) {
+			return cert;
+		}
 		const last_validated = validated_passes.get(code);
 		if (last_validated && last_validated > Date.now() - prevent_revalidation_before_ms) {
 			const duration_minutes = ((Date.now() - last_validated) / 60 / 1000) | 0;


### PR DESCRIPTION
La CNIL demande à ne pas stocker de données personnelles (juste le temps de vérifier). 
Pour ne pas provoquer de régression avec le reste, j'ai ajouté un test qui retourne le cert si on a configuré de ne pas attendre entre plusieurs validation d'un même pass.

_GESTION DES DONNÉES PERSONNELLES - La Loi n° 2021-689 du 31 mai 2021 relative à la gestion de la sortie de crise sanitaire, et ses décrets d’application disposent qu’il est scrupuleusement interdit de conserver la moindre information relative au contrôle d’un Pass Sanitaire.
Qu’il s’agisse du résultat de la vérification d’un Pass (valide/non Valide) ou d’une donnée telle que nom, prénom, date de naissance du porteur du Pass, ces données sont considérées comme personnelles, et sensibles (données médicales), et ne doivent pas être manipulées sous quelque forme que ce soit, par le contrôleur du Pass Sanitaire, la seule « manipulation » est celle réalisée par l’application mobile qui affiche un résultat pendant 30 secondes, résultat qui ne doit en aucun cas être conservé (pas de copie d’écran, d’impression…)_ 