### PR TITLE
Corrections temporaires pours les certificats ukrainiens

### DIFF
--- a/src/assets/DCC.combined-schema.1.3.0.json
+++ b/src/assets/DCC.combined-schema.1.3.0.json
@@ -32,7 +32,7 @@
 			"title": "Date of birth",
 			"description": "Date of Birth of the person addressed in the DCC. ISO 8601 date format restricted to range 1900-2099 or empty",
 			"type": "string",
-			"pattern": "^((\\d\\d\\.){0,2}(19|20)\\d\\d|(19|20)\\d\\d(-\\d\\d){0,2}){0,1}$",
+			"pattern": "^((\\d\\d\\.){2}(19|20)\\d\\d|(19|20)\\d\\d(-\\d\\d){0,2}){0,1}$",
 			"examples": ["1979-04-14", "1950", "1901-08", ""]
 		},
 		"v": {

--- a/src/assets/DCC.combined-schema.1.3.0.json
+++ b/src/assets/DCC.combined-schema.1.3.0.json
@@ -32,7 +32,7 @@
 			"title": "Date of birth",
 			"description": "Date of Birth of the person addressed in the DCC. ISO 8601 date format restricted to range 1900-2099 or empty",
 			"type": "string",
-			"pattern": "^((19|20)\\d\\d(-\\d\\d){0,2}){0,1}$",
+			"pattern": "^((\\d\\d\\.){0,2}(19|20)\\d\\d|(19|20)\\d\\d(-\\d\\d){0,2}){0,1}$",
 			"examples": ["1979-04-14", "1950", "1901-08", ""]
 		},
 		"v": {
@@ -90,7 +90,7 @@
 					"title": "Standardised surname",
 					"description": "The surname(s) of the person, transliterated ICAO 9303",
 					"type": "string",
-					"pattern": "^[A-Z<,]*$",
+					"pattern": "^[A-Za-z<,]*$",
 					"maxLength": 80,
 					"examples": ["DCERVENKOVA<PANKLOVA"]
 				},
@@ -105,7 +105,7 @@
 					"title": "Standardised forename",
 					"description": "The forename(s) of the person, transliterated ICAO 9303",
 					"type": "string",
-					"pattern": "^[A-Z<,]*$",
+					"pattern": "^[A-Za-z<,]*$",
 					"maxLength": 80,
 					"examples": ["JIRINA<MARIA<ALENA"]
 				}

--- a/src/lib/digital_green_certificate.ts
+++ b/src/lib/digital_green_certificate.ts
@@ -211,10 +211,14 @@ async function getCertificatePublicKey({
 
 function getCertificateInfo(cert: DGC): CommonCertificateInfo {
 	const hcert = cert.hcert;
+	let dob = hcert.dob;
+	if (dob.search(/^(\d\d\.){2}(19|20)\d\d$/) != -1) {
+		dob = dob.split('.').reverse().join('-');
+	}
 	const common = {
 		first_name: hcert.nam.gn || (hcert.nam.gnt || '-').replace(/</g, ' '),
 		last_name: hcert.nam.fn || hcert.nam.fnt.replace(/</g, ' '),
-		date_of_birth: new Date(hcert.dob),
+		date_of_birth: new Date(dob),
 		code: cert.code,
 		source: { format: 'dgc', cert }
 	} as const;


### PR DESCRIPTION
Bonjour
Ukraine vient d'être acceptée dans le système des certificats verts, mais malheuresement notre ministère n'a pas reussi de former un JSON sans fautes. J'ai fait un fix temporaire pour changer la schema de validation pour les certificats provenant d'Ukraine. Je suis pas un développeur JS, mais ça a l'air de marcher pour moi (j'ai testé avec les certificats Ukrainiens et Allemands).

PS: merci pour le service et félicitations :) 