### PR TITLE
borne: Ajout de la possibilité d'imprimer des tickets.

### DIFF
--- a/src/lib/borne_config.ts
+++ b/src/lib/borne_config.ts
@@ -30,6 +30,8 @@ export interface ConfigProperties {
 	// whereas a sound explicitly set to null is interpreted as no sound.
 	sound_valid?: string | null;
 	sound_invalid?: string | null;
+	// printing ticket
+	ticketConfig: TicketConfig;
 }
 
 export const DEFAULT_CONFIG: ConfigProperties = {
@@ -45,5 +47,6 @@ export const DEFAULT_CONFIG: ConfigProperties = {
 	bottom_infos: 'logiciel sanipasse.fr fourni par Ophir Lojkine sous licence AGPLv3.',
 	anonymize: false,
 	prevent_revalidation_before_minutes: 0,
-	video_scan: true
+	video_scan: true,
+	ticketConfig: {print:false}
 };

--- a/src/lib/ticket.ts
+++ b/src/lib/ticket.ts
@@ -1,0 +1,81 @@
+export interface TicketConfig {
+	print: boolean;
+	header?: string | null;
+	footer?: string | null;
+	width: number;
+}
+
+function getTicketHtml(
+    name: String = "",
+    date_of_birth: String = "",
+    config: TicketConfig
+  ): String{
+  if(undefined == config.width){
+    config.width = 90;
+  }
+  let html: String = `
+<style type="text/css">
+  body{
+    width: `+config.width+`mm;
+  }
+  p{
+    padding: 0;
+    margin: 1mm;
+  }
+  input{
+    border: none;
+    border-bottom: 0.5mm dotted black;
+    width: calc( `+config.width+`mm - 20mm );
+  }
+  article{
+    margin: 2mm 0;
+  }
+  header pre,
+  footer pre{
+    text-align: center;
+  }
+</style>
+
+<body>
+  `;
+  if(undefined != config.header){
+    html = html.concat(
+      `<header><pre>`,
+      config.header,
+      `</pre></header>`
+    )
+  }
+  html = html.concat(`
+  <article>
+    <p>👤 `,name,`</p>
+    <p>🎂 Né(e) le `,date_of_birth,`</p>
+    <p>📱 Tél: <input></p>
+    <p>✓ Vérifié le `,new Date().toLocaleString('fr-FR'),`</p>
+  </article>
+  `)
+  if(undefined != config.footer){
+    html = html.concat(
+      `<footer><pre>`,
+      config.footer,
+      `</pre></footer>`
+    )
+  }
+  html = html.concat(`
+</body>
+` )
+  return html;
+}
+
+export async function printTicket(
+    name: String = "",
+    date_of_birth: String = "",
+    config: TicketConfig
+  ){
+  const printingWindow = window.open("about:blank", 'Printing', 'width=350,height=300');
+  printingWindow.onload = ()=>{
+    printingWindow.document.title = "Sanipasse impression"
+    printingWindow.document.body.innerHTML = getTicketHtml(name, date_of_birth, config);
+    printingWindow.print();
+    printingWindow.close();
+  }
+}

--- a/src/routes/borne/_configTicket.svelte
+++ b/src/routes/borne/_configTicket.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import type { TicketConfig } from '$lib/borne_config';
+
+	export let config:TicketConfig;
+</script>
+
+<fieldset class="col-12">
+	<div class="row">
+		<label class="col-6">
+			<input type="checkbox" bind:checked={config.print} />
+			Imprimer un ticket en cas de présentation d'un passe valide.
+		</label>
+		<div
+			class="form-label col-6"
+			title="Largeur du ticket à imprimer"
+		>
+			<label for="ticketWidth">Largeur du ticket</label>
+			<div class="input-group">
+				<input
+					type="number"
+					class="form-control"
+					placeholder="90"
+					id="ticketWidth"
+					bind:value={config.width}
+					min="70" max="210"
+				/>
+				<div class="input-group-text">mm</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="form-floating col-6 font-monospace text-muted">
+			<textarea
+				bind:value={config.header}
+				class="form-control"
+				placeholder={'Bienvenue dans notre établissement.'}
+				id="ticket_header"
+				style="height: 7em"
+			/>
+			<label for="ticket_header">Entête</label>
+		</div>
+		<div class="form-floating col-6 font-monospace text-muted">
+			<textarea
+				bind:value={config.footer}
+				class="form-control"
+				placeholder={'Merci de votre visite.'}
+				id="ticket_footer"
+				style="height: 7em"
+			/>
+			<label for="ticket_footer">Pied de page</label>
+		</div>
+	</div>
+</fieldset>

--- a/src/routes/borne/_scan.svelte
+++ b/src/routes/borne/_scan.svelte
@@ -5,6 +5,7 @@
 	import type { ConfigProperties, HTTPRequest } from '$lib/borne_config';
 	import QrCodeVideoReader from '../_QrCodeVideoReader.svelte';
 	import { sha256 } from '$lib/sha256';
+	import { printTicket } from '$lib/ticket';
 
 	export let config: ConfigProperties;
 	const { decode_after_s, reset_after_s, prevent_revalidation_before_minutes } = config;
@@ -66,7 +67,15 @@
 		return externalRequest;
 	}
 
-	async function onValid() {
+	async function onValid(decodedPass) {
+		if(config.ticketConfig.print){
+			console.log("Printing ticket");
+			printTicket(
+				showName(decodedPass),
+				decodedPass.date_of_birth.toLocaleDateString('fr'),
+				config.ticketConfig
+			);
+		}
 		if (config.external_requests && config.external_requests.accepted.url)
 			return makeRequest(config.external_requests.accepted);
 	}

--- a/src/routes/borne/config.svelte
+++ b/src/routes/borne/config.svelte
@@ -9,6 +9,7 @@
 	import { get, put } from '$lib/http';
 	import ShowPromiseError from '../_showPromiseError.svelte';
 	import SoundPicker from './_sound_picker.svelte';
+	import TicketConfig from './_configTicket.svelte';
 
 	let configKey: string = '';
 	if (typeof window === 'object') configKey = new URLSearchParams(location.search).get('key') || '';
@@ -359,6 +360,14 @@
 			</details>
 		</div>
 	</fieldset>
+
+	<details>
+		<summary>Impression de tickets</summary>
+			<TicketConfig
+				bind:config={config.ticketConfig}
+			/>
+	</details>
+
 	<details>
 		<summary>Requêtes HTTP externe</summary>
 		<ExternalRequestsConfig bind:external_requests={config.external_requests} />


### PR DESCRIPTION
Ajoute la possibilité, pour la borne, d'imprimer automatiquement un ticket.

### Configuration de la borne
On peut :
 - activer ou non l'option
 - fixer la largeur du ticket
 - configurer un entête et un pied de page
 
### Le ticket
Il comprend
 - l'entête (s'il est défini)
 - le nom
 - la date de naissance
 - une ligne pour noter le numéro de téléphone pour servir de *cahier de rappel* covid
 - la date et l'heure de la vérification
 - le pied de page (s'il est défini)

pour que le navigateur de la borne imprime automatiquement :
```chromium --kiosk-printing https://sanipasse.fr/```